### PR TITLE
Fix category parsing and prevent future format issues

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,6 +55,8 @@ assets/
 - **Test**: Always verify GitHub Pages compatibility
 
 ### Category Management
+**CRITICAL**: Always use YAML array format for categories, never single strings.
+
 Current categories (use exact formatting):
 - "Administrator"
 - "Microsoft"
@@ -66,6 +68,17 @@ Current categories (use exact formatting):
 - "Infrastructure"
 - "Athletics"
 - "Review"
+
+**Correct format:**
+```yaml
+categories:
+- "Category Name"
+```
+
+**WRONG format (breaks category parsing):**
+```yaml
+categories: "Category Name"
+```
 
 ### Git Workflow (CI/CD Protected)
 **CRITICAL: Direct commits to `main` are BLOCKED by branch protection rules**
@@ -108,8 +121,8 @@ Current categories (use exact formatting):
 ---
 title: "Your Title Here"        # REQUIRED - validation enforced
 date: YYYY-MM-DD               # REQUIRED - must be YYYY-MM-DD format
-categories:                    # REQUIRED - at least one category
-- "Category Name"
+categories:                    # REQUIRED - MUST use YAML array format
+- "Category Name"               # CRITICAL: Never use single string format
 excerpt: "Brief description for SEO and previews..."
 tags:
 - relevant-tag

--- a/_posts/2025-08-04-building-resilient-infrastructure.md
+++ b/_posts/2025-08-04-building-resilient-infrastructure.md
@@ -2,7 +2,8 @@
 layout: post
 title: "Building Resilient IT Infrastructure for Growing Organizations"
 date: 2025-08-04
-categories: "Infrastructure"
+categories:
+- "Infrastructure"
 excerpt: "Lessons learned from rebuilding enterprise IT systems at scale. When your organization is growing from $185M to $300M in revenue, your infrastructure needs to be ready for the challenge."
 ---
 

--- a/_posts/2025-08-05-sample-post.md
+++ b/_posts/2025-08-05-sample-post.md
@@ -2,7 +2,8 @@
 layout: post
 title: "Sample Post - Getting Started"
 date: 2025-08-05
-categories: "Getting Started"
+categories:
+- "Getting Started"
 ---
 
 This is a sample post for the Jekyll-powered GitHub Pages site structure.


### PR DESCRIPTION
## Summary
- Fixed "Getting Started" category appearing as two separate categories on categories page
- Updated CLAUDE.md instructions with critical warnings about YAML category format requirements
- Converted posts using single-string format to proper YAML array format

## Changes Made
- **Fixed posts**: Updated sample post and infrastructure post to use `categories:` array format instead of single string
- **Updated instructions**: Added explicit warnings and examples in CLAUDE.md about correct category format
- **Prevention**: Added critical format requirements to frontmatter template

## Test Plan
- [x] Verify category parsing logic handles corrected format
- [x] Confirm "Getting Started" appears as single category
- [x] Updated instructions clearly warn about format requirements
- [x] All posts now use consistent YAML array format

🤖 Generated with [Claude Code](https://claude.ai/code)